### PR TITLE
Migrate site to GitHub Pages with custom domain support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,9 +32,6 @@ jobs:
         run: |
           if [ "${{ github.repository }}" = "plus-hi/techladies-staging" ]; then
             echo "NEXT_PUBLIC_BASE_PATH=/techladies-staging" >> $GITHUB_ENV
-          elif [ "${{ github.repository }}" = "TechLadies/website" ]; then
-            # Remove this line once custom domain (techladies.co) is configured
-            echo "NEXT_PUBLIC_BASE_PATH=/website" >> $GITHUB_ENV
           fi
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Migrate from Vercel to GitHub Pages with static export (`output: 'export'`)
- Add GitHub Pages deployment workflow with base path support for staging
- Remove `/website` base path now that custom domain (`techladies.co`) is configured
- Update site content: new Programs sections, community links (Instagram/LinkedIn), dependency updates
- Fix image paths, button spacing, and ESLint errors for GitHub Pages compatibility

## Test plan
- [ ] Verify site loads correctly at `techladies.co` without `/website/` prefix in URLs
- [ ] Verify all images and links resolve correctly
- [ ] Verify staging at `plus-hi.github.io/techladies-staging` still works
- [ ] Check navigation between pages works with `trailingSlash: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)